### PR TITLE
[TMP] add pre-init-hook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+openupgradelib

--- a/server_action_mass_edit/README.rst
+++ b/server_action_mass_edit/README.rst
@@ -17,13 +17,13 @@ Mass Editing
     :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
     :alt: License: AGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-OCA%2Fserver--ux-lightgray.png?logo=github
-    :target: https://github.com/OCA/server-ux/tree/17.0/server_action_mass_edit
+    :target: https://github.com/OCA/server-ux/tree/18.0/server_action_mass_edit
     :alt: OCA/server-ux
 .. |badge4| image:: https://img.shields.io/badge/weblate-Translate%20me-F47D42.png
-    :target: https://translation.odoo-community.org/projects/server-ux-17-0/server-ux-17-0-server_action_mass_edit
+    :target: https://translation.odoo-community.org/projects/server-ux-18-0/server-ux-18-0-server_action_mass_edit
     :alt: Translate me on Weblate
 .. |badge5| image:: https://img.shields.io/badge/runboat-Try%20me-875A7B.png
-    :target: https://runboat.odoo-community.org/builds?repo=OCA/server-ux&target_branch=17.0
+    :target: https://runboat.odoo-community.org/builds?repo=OCA/server-ux&target_branch=18.0
     :alt: Try me on Runboat
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
@@ -76,7 +76,7 @@ Configuration
    action with a domain.
 -  You can add an extra message that will be displayed in the wizard.
 
-.. |Configuration| image:: https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing_form.png
+.. |Configuration| image:: https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing_form.png
 
 Usage
 =====
@@ -95,9 +95,9 @@ Usage
 
 |Wizard Result|
 
-.. |Action| image:: https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-item_tree.png
-.. |Wizard Form| image:: https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-wizard_form.png
-.. |Wizard Result| image:: https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-item_tree-result.png
+.. |Action| image:: https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-item_tree.png
+.. |Wizard Form| image:: https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-wizard_form.png
+.. |Wizard Result| image:: https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-item_tree-result.png
 
 Known issues / Roadmap
 ======================
@@ -110,7 +110,7 @@ Bug Tracker
 Bugs are tracked on `GitHub Issues <https://github.com/OCA/server-ux/issues>`_.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-`feedback <https://github.com/OCA/server-ux/issues/new?body=module:%20server_action_mass_edit%0Aversion:%2017.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+`feedback <https://github.com/OCA/server-ux/issues/new?body=module:%20server_action_mass_edit%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
 
 Do not contact contributors directly about support or help with technical issues.
 
@@ -142,6 +142,13 @@ Contributors
    -  Víctor Martínez
 
 -  Tatiana Deribina <tatiana.deribina@spritnit.fi>
+-  Tris Doan <tridm@trobz.com>
+
+Other credits
+-------------
+
+The migration of this module from 17.0 to 18.0 was financially supported
+by Camptocamp.
 
 Maintainers
 -----------
@@ -156,6 +163,6 @@ OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.
 
-This module is part of the `OCA/server-ux <https://github.com/OCA/server-ux/tree/17.0/server_action_mass_edit>`_ project on GitHub.
+This module is part of the `OCA/server-ux <https://github.com/OCA/server-ux/tree/18.0/server_action_mass_edit>`_ project on GitHub.
 
 You are welcome to contribute. To learn how please visit https://odoo-community.org/page/Contribute.

--- a/server_action_mass_edit/__init__.py
+++ b/server_action_mass_edit/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import pre_init_hook

--- a/server_action_mass_edit/__manifest__.py
+++ b/server_action_mass_edit/__manifest__.py
@@ -27,4 +27,6 @@
         ]
     },
     "demo": ["demo/mass_editing.xml"],
+    "external_dependencies": {"python": ["openupgradelib"]},
+    "pre_init_hook": "pre_init_hook",
 }

--- a/server_action_mass_edit/__manifest__.py
+++ b/server_action_mass_edit/__manifest__.py
@@ -2,7 +2,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Mass Editing",
-    "version": "17.0.1.0.1",
+    "version": "18.0.1.0.0",
     "author": "Serpent Consulting Services Pvt. Ltd., "
     "Tecnativa, "
     "GRAP, "

--- a/server_action_mass_edit/hooks.py
+++ b/server_action_mass_edit/hooks.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Camptocamp (<https://www.camptocamp.com>)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+from openupgradelib import openupgrade
+
+
+def pre_init_hook(env):
+    if openupgrade.table_exists(env.cr, "mass_editing_line"):
+        openupgrade.rename_models(
+            env.cr, [("mass.editing.line", "ir.actions.server.mass.edit.line")]
+        )
+        openupgrade.rename_tables(
+            env.cr, [("mass_editing_line", "ir_actions_server_mass_edit_line")]
+        )
+
+        modules = [("mass_editing", "server_action_mass_edit")]
+        openupgrade.update_module_names(env.cr, modules, merge_modules=True)

--- a/server_action_mass_edit/models/ir_actions_server_mass_edit_line.py
+++ b/server_action_mass_edit/models/ir_actions_server_mass_edit_line.py
@@ -28,15 +28,14 @@ class IrActionsServerMassEditLine(models.Model):
     field_id = fields.Many2one(
         "ir.model.fields",
         string="Field",
-        domain="""
+        domain=f"""
             [
-                ("name", "not in", %s),
+                ("name", "not in", {str(MAGIC_FIELDS)}),
                 ("ttype", "not in", ["reference", "function"]),
                 ("model_id", "=", model_id),
                 ("readonly", "!=", True),
             ]
-        """
-        % str(MAGIC_FIELDS),
+        """,
         ondelete="cascade",
         required=True,
     )

--- a/server_action_mass_edit/readme/CONTRIBUTORS.md
+++ b/server_action_mass_edit/readme/CONTRIBUTORS.md
@@ -10,3 +10,4 @@
   - Jairo Llopis
   - Víctor Martínez
 - Tatiana Deribina \<<tatiana.deribina@spritnit.fi>\>
+- Tris Doan \<<tridm@trobz.com>\>

--- a/server_action_mass_edit/readme/CREDITS.md
+++ b/server_action_mass_edit/readme/CREDITS.md
@@ -1,0 +1,1 @@
+The migration of this module from 17.0 to 18.0 was financially supported by Camptocamp.

--- a/server_action_mass_edit/static/description/index.html
+++ b/server_action_mass_edit/static/description/index.html
@@ -369,7 +369,7 @@ ul.auto-toc {
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !! source digest: sha256:a91c225a06ba8d7292d92a9cf99286ed5e4128715d60e02589acaf1e09361aa0
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
-<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/server-ux/tree/17.0/server_action_mass_edit"><img alt="OCA/server-ux" src="https://img.shields.io/badge/github-OCA%2Fserver--ux-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/server-ux-17-0/server-ux-17-0-server_action_mass_edit"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/server-ux&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
+<p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/agpl-3.0-standalone.html"><img alt="License: AGPL-3" src="https://img.shields.io/badge/licence-AGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/server-ux/tree/18.0/server_action_mass_edit"><img alt="OCA/server-ux" src="https://img.shields.io/badge/github-OCA%2Fserver--ux-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/server-ux-18-0/server-ux-18-0-server_action_mass_edit"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/server-ux&amp;target_branch=18.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
 <p>This module allows to edit several records at the same time in any Odoo
 model</p>
 <p><strong>Difference in comparison to the Odoo Feature</strong></p>
@@ -395,7 +395,8 @@ color fields, image fields, etc…)</li>
 <li><a class="reference internal" href="#credits" id="toc-entry-5">Credits</a><ul>
 <li><a class="reference internal" href="#authors" id="toc-entry-6">Authors</a></li>
 <li><a class="reference internal" href="#contributors" id="toc-entry-7">Contributors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-8">Maintainers</a></li>
+<li><a class="reference internal" href="#other-credits" id="toc-entry-8">Other credits</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-9">Maintainers</a></li>
 </ul>
 </li>
 </ul>
@@ -412,7 +413,7 @@ Actions</em></li>
 <li>Add the security groups allowed to use this action</li>
 <li>Add the fields you want to be mass edited</li>
 </ul>
-<p><img alt="Configuration" src="https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing_form.png" /></p>
+<p><img alt="Configuration" src="https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing_form.png" /></p>
 <ul class="simple">
 <li><em>Add Action</em>: Click on <em>Create Contextual Action</em> to add mass editing
 in <em>Action</em> menu.</li>
@@ -432,16 +433,16 @@ action with a domain.</li>
 <li><em>Go for Mass Editing</em>: select the records which you want to modify
 and click on <em>Action</em> to open mass editing popup.</li>
 </ul>
-<p><img alt="Action" src="https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-item_tree.png" /></p>
+<p><img alt="Action" src="https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-item_tree.png" /></p>
 <ul class="simple">
 <li>Select <em>Set / Remove</em> action and write down the value to set or
 remove the value for the given field.</li>
 </ul>
-<p><img alt="Wizard Form" src="https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-wizard_form.png" /></p>
+<p><img alt="Wizard Form" src="https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-wizard_form.png" /></p>
 <ul class="simple">
 <li>This way you can set / remove the values of the fields.</li>
 </ul>
-<p><img alt="Wizard Result" src="https://raw.githubusercontent.com/OCA/server-ux/17.0/server_action_mass_edit/static/description/mass_editing-item_tree-result.png" /></p>
+<p><img alt="Wizard Result" src="https://raw.githubusercontent.com/OCA/server-ux/18.0/server_action_mass_edit/static/description/mass_editing-item_tree-result.png" /></p>
 </div>
 <div class="section" id="known-issues-roadmap">
 <h1><a class="toc-backref" href="#toc-entry-3">Known issues / Roadmap</a></h1>
@@ -454,7 +455,7 @@ remove the value for the given field.</li>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/OCA/server-ux/issues">GitHub Issues</a>.
 In case of trouble, please check there if your issue has already been reported.
 If you spotted it first, help us to smash it by providing a detailed and welcomed
-<a class="reference external" href="https://github.com/OCA/server-ux/issues/new?body=module:%20server_action_mass_edit%0Aversion:%2017.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
+<a class="reference external" href="https://github.com/OCA/server-ux/issues/new?body=module:%20server_action_mass_edit%0Aversion:%2018.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**">feedback</a>.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
@@ -485,10 +486,16 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </li>
 <li>Tatiana Deribina &lt;<a class="reference external" href="mailto:tatiana.deribina&#64;spritnit.fi">tatiana.deribina&#64;spritnit.fi</a>&gt;</li>
+<li>Tris Doan &lt;<a class="reference external" href="mailto:tridm&#64;trobz.com">tridm&#64;trobz.com</a>&gt;</li>
 </ul>
 </div>
+<div class="section" id="other-credits">
+<h2><a class="toc-backref" href="#toc-entry-8">Other credits</a></h2>
+<p>The migration of this module from 17.0 to 18.0 was financially supported
+by Camptocamp.</p>
+</div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-9">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
 <a class="reference external image-reference" href="https://odoo-community.org">
 <img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
@@ -496,7 +503,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>
-<p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-ux/tree/17.0/server_action_mass_edit">OCA/server-ux</a> project on GitHub.</p>
+<p>This module is part of the <a class="reference external" href="https://github.com/OCA/server-ux/tree/18.0/server_action_mass_edit">OCA/server-ux</a> project on GitHub.</p>
 <p>You are welcome to contribute. To learn how please visit <a class="reference external" href="https://odoo-community.org/page/Contribute">https://odoo-community.org/page/Contribute</a>.</p>
 </div>
 </div>

--- a/server_action_mass_edit/static/src/js/record.esm.js
+++ b/server_action_mass_edit/static/src/js/record.esm.js
@@ -1,4 +1,3 @@
-/** @odoo-module **/
 import {Record} from "@web/model/relational_model/record";
 import {patch} from "@web/core/utils/patch";
 

--- a/server_action_mass_edit/static/src/js/static_list.esm.js
+++ b/server_action_mass_edit/static/src/js/static_list.esm.js
@@ -1,4 +1,3 @@
-/** @odoo-module **/
 import {StaticList} from "@web/model/relational_model/static_list";
 import {markRaw} from "@odoo/owl";
 import {patch} from "@web/core/utils/patch";

--- a/server_action_mass_edit/tests/test_mass_editing.py
+++ b/server_action_mass_edit/tests/test_mass_editing.py
@@ -168,7 +168,7 @@ class TestMassEditing(common.TransactionCase):
         ).get_view(view_id=view_id.id)
         arch = result.get("arch", "")
         self.assertIn(
-            "<tree editable=",
+            "<list editable=",
             arch,
             "Fields view get must return architecture with embedded tree",
         )

--- a/server_action_mass_edit/views/ir_actions_server.xml
+++ b/server_action_mass_edit/views/ir_actions_server.xml
@@ -8,7 +8,7 @@
                 <notebook invisible="state != 'mass_edit'">
                     <page name="mass_edit_line_ids" string="Fields">
                         <field name="mass_edit_line_ids" nolabel="1">
-                            <tree editable="bottom">
+                            <list editable="bottom">
                                 <field name="model_id" column_invisible="True" />
                                 <field
                                     name="server_action_id"
@@ -21,7 +21,7 @@
                                 />
                                 <field name="widget_option" />
                                 <field name="apply_domain" />
-                            </tree>
+                            </list>
                         </field>
                         <field name="mass_edit_apply_domain_in_lines" invisible="1" />
                         <div

--- a/server_action_mass_edit/views/ir_actions_server.xml
+++ b/server_action_mass_edit/views/ir_actions_server.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
-
     <record id="view_server_action_form" model="ir.ui.view">
         <field name="model">ir.actions.server</field>
         <field name="inherit_id" ref="base.view_server_action_form" />
@@ -31,7 +30,7 @@
                             invisible="not mass_edit_apply_domain_in_lines"
                         >
                             <b
-                            >WARNING</b>: Take into account that adding a field with a domain, and not including the fields of such domain in this operation definition, will lead to an error when trying to perform it. Make sure you include them.
+                        >WARNING</b>: Take into account that adding a field with a domain, and not including the fields of such domain in this operation definition, will lead to an error when trying to perform it. Make sure you include them.
                         </div>
                     </page>
                     <page name="mass_edit_message" string="Message">

--- a/server_action_mass_edit/wizard/mass_editing_wizard.py
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.py
@@ -91,7 +91,7 @@ class MassEditingWizard(models.TransientModel):
             values[line.field_id.name] = False
 
             dynamic_fields["selection__" + line.field_id.name] = fields.Selection(
-                [()], default="ignore"
+                [], default="ignore"
             )
 
             dynamic_fields[line.field_id.name] = fields.Text([()], default=False)
@@ -180,33 +180,33 @@ class MassEditingWizard(models.TransientModel):
         if field.ttype == "one2many":
             comodel = self.env[field.relation]
             dummy, form_view = comodel._get_view(view_type="form")
-            dummy, tree_view = comodel._get_view(view_type="tree")
+            dummy, list_view = comodel._get_view(view_type="list")
             field_context = {}
             if form_view:
                 field_context["form_view_ref"] = form_view.xml_id
-            if tree_view:
-                field_context["tree_view_ref"] = tree_view.xml_id
+            if list_view:
+                field_context["list_view_ref"] = list_view.xml_id
             if field_context:
                 field_element.attrib["context"] = json.dumps(field_context)
             else:
                 model_arch, dummy = self.env[field.model]._get_view(view_type="form")
-                embedded_tree = None
-                for node in model_arch.xpath(f"//field[@name='{field.name}'][./tree]"):
-                    embedded_tree = node.xpath("./tree")[0]
+                embedded_list = None
+                for node in model_arch.xpath(f"//field[@name='{field.name}'][./list]"):
+                    embedded_list = node.xpath("./list")[0]
                     break
-                if embedded_tree is not None:
-                    for node in embedded_tree.xpath("./*"):
+                if embedded_list is not None:
+                    for node in embedded_list.xpath("./*"):
                         modifiers = node.get("modifiers")
                         if modifiers:
                             node.attrib["modifiers"] = modifiers
-                    field_element.insert(0, embedded_tree)
+                    field_element.insert(0, embedded_list)
 
         return field_element
 
     def _get_field_options(self, field):
         return {
             "name": field.name,
-            "invisible": 'selection__%s in ["ignore", "remove", False]' % field.name,
+            "invisible": f'selection__{field.name} in ["ignore", "remove", False]',
             "class": "w-75",
         }
 

--- a/server_action_mass_edit/wizard/mass_editing_wizard.xml
+++ b/server_action_mass_edit/wizard/mass_editing_wizard.xml
@@ -35,8 +35,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
                 >
                     <field name="operation_description_danger" />
                 </p>
-                <group name="group_field_list">
-                </group>
+                <group name="group_field_list" />
                 <footer>
                     <button
                         string="Apply"


### PR DESCRIPTION
### Context
- migration script was actually added in `https://github.com/OCA/server-ux/pull/544/commits/ef9b11793cd200aee9cdade5e2e56c299c6d86f9`
- But wrongly dropped during migration to 17.0: `https://github.com/OCA/server-ux/pull/872`

### This changes
- add pre-init-hook to adapt current state of data
(one appealing reason using hook is `https://github.com/OCA/product-attribute/pull/1215#discussion_r1213301984`)