### PR TITLE
[TMP] add pre-init-hook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# generated from manifests external_dependencies
+openupgradelib

--- a/server_action_mass_edit/__init__.py
+++ b/server_action_mass_edit/__init__.py
@@ -1,2 +1,3 @@
 from . import models
 from . import wizard
+from .hooks import pre_init_hook

--- a/server_action_mass_edit/__manifest__.py
+++ b/server_action_mass_edit/__manifest__.py
@@ -27,4 +27,6 @@
         ]
     },
     "demo": ["demo/mass_editing.xml"],
+    "external_dependencies": {"python": ["openupgradelib"]},
+    "pre_init_hook": "pre_init_hook",
 }

--- a/server_action_mass_edit/hooks.py
+++ b/server_action_mass_edit/hooks.py
@@ -1,0 +1,16 @@
+# Copyright 2024 Camptocamp (<https://www.camptocamp.com>)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)
+from openupgradelib import openupgrade
+
+
+def pre_init_hook(env):
+    if openupgrade.table_exists(env.cr, "mass_editing_line"):
+        openupgrade.rename_models(
+            env.cr, [("mass.editing.line", "ir.actions.server.mass.edit.line")]
+        )
+        openupgrade.rename_tables(
+            env.cr, [("mass_editing_line", "ir_actions_server_mass_edit_line")]
+        )
+
+        modules = [("mass_editing", "server_action_mass_edit")]
+        openupgrade.update_module_names(env.cr, modules, merge_modules=True)


### PR DESCRIPTION
### Note
- Please spare the failing text. It happened due to 1 issue in base_technical_features (fixed in [here](https://github.com/trisdoan/server-ux/pull/4))
- The bug was the consequence of refactor in model base: `https://github.com/OCA/server-ux/pull/953/commits/6de17cff813d167b9454635d6ebecf9ef0e0dcad#diff-e22d1d26f78a61590410c962a927a7cda2fd3cc5969899386301039948b67a5c`

### This changes
- add pre-init-hook to adapt current state of data
(one appealing reason using hook is `https://github.com/OCA/product-attribute/pull/1215#discussion_r1213301984`)